### PR TITLE
fixed symfony 2.4 requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "doctrine/doctrine-bundle": ">=1.2.0,<1.3-dev",
         "prezent/doctrine-translatable": "dev-master",
-        "symfony/symfony": ">=2.2,<=2.4"
+        "symfony/symfony": ">=2.2,<2.5-dev"
     },
     "autoload": {
         "psr-0": { "Prezent\\Doctrine\\TranslatableBundle": "" }


### PR DESCRIPTION
allow ALL 2.4.\* symfony versions. sorry for the previous PR
