### PR TITLE
LocaleListener: rise priority to set currentLocale sooner

### DIFF
--- a/EventListener/LocaleListener.php
+++ b/EventListener/LocaleListener.php
@@ -53,7 +53,7 @@ class LocaleListener implements EventSubscriberInterface
     static public function getSubscribedEvents()
     {
         return array(
-            KernelEvents::REQUEST => 'onKernelRequest',
+            KernelEvents::REQUEST => array(array('onKernelRequest', 10)),
         );
     }
 }


### PR DESCRIPTION
`LocaleListener` should be subscribed to the `kernel.request` event with higher priority.
Some other `kernel.request` listeners (with default priority) can grab entities from database and hydrate them before `currentLocale` was set.

This PR should fix these cases by setting the `LocaleListener`'s priority to 10 (the same priority that has `Symfony\Component\HttpKernel\EventListener\TranslatorListener` which does basically the same as `LocaleListener`).

To be specific I had a problem that `Symfony\Component\Security\Http\Firewall::onKernelRequest()` (priority 8) was dependent on a service that loaded few entities from database and those entities had currentLocale "en" instead of the locale resolved from `Request`.

For better overview, these are the default `kernel.request` listeners in Symfony 3:
```
"kernel.request" event
----------------------

 ------- ---------------------------------------------------------------------------------- ---------- 
  Order   Callable                                                                           Priority  
 ------- ---------------------------------------------------------------------------------- ---------- 
  #1      Symfony\Component\HttpKernel\EventListener\DebugHandlersListener::configure()      2048      
  #2      Symfony\Component\HttpKernel\EventListener\DumpListener::configure()               1024      
  #3      Symfony\Bundle\FrameworkBundle\EventListener\SessionListener::onKernelRequest()    128       
  #4      Symfony\Component\HttpKernel\EventListener\FragmentListener::onKernelRequest()     48        
  #5      Symfony\Component\HttpKernel\EventListener\RouterListener::onKernelRequest()       32        
  #6      Symfony\Component\HttpKernel\EventListener\LocaleListener::onKernelRequest()       16        
  #7      Symfony\Component\HttpKernel\EventListener\TranslatorListener::onKernelRequest()   10        
  #8      Symfony\Component\Security\Http\Firewall::onKernelRequest()                        8         
 ------- ---------------------------------------------------------------------------------- ---------- 
```