### PR TITLE
use composer recommended installation method in docs

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -11,20 +11,10 @@ This bundle requires Symfony 2.2+.
 
 ### Step 1: Download using Composer
 
-Add this bundle to your composer.json:
-
-```js
-{
-    "require": {
-        "prezent/doctrine-translatable-bundle": "dev-master"
-    }
-}
-```
-
 Tell Composer to install the bundle:
 
 ```bash
-$ php composer.phar update prezent/doctrine-translatable-bundle
+$ php composer.phar require prezent/doctrine-translatable-bundle
 ```
 
 ### Step 2: Enable the bundle


### PR DESCRIPTION
This is a simple PR to update the outdated composer install method.

Telling users to depend on `dev-master` is not a good idea.