### PR TITLE
PrezentDoctrineTranslatableExtension: fix undefined variable

### DIFF
--- a/DependencyInjection/PrezentDoctrineTranslatableExtension.php
+++ b/DependencyInjection/PrezentDoctrineTranslatableExtension.php
@@ -37,10 +37,13 @@ class PrezentDoctrineTranslatableExtension extends Extension
                   ->addMethodCall('setCurrentLocale', array($config['fallback_locale']))
                   ->addMethodCall('setFallbackLocale', array($config['fallback_locale']));
 
-        $this->loadSonata();
+        $this->loadSonata($container);
     }
 
-    private function loadSonata()
+    /**
+     * @param ContainerBuilder $container
+     */
+    private function loadSonata(ContainerBuilder $container)
     {
         $bundles = $container->getParameter('kernel.bundles');
 


### PR DESCRIPTION
The latest release 1.0.4 has broken `PrezentDoctrineTranslatableExtension` - the `$container` variable isn't passed to the `loadSonata` method.

Please, release 1.0.5 with this patch as the package cannot be used in its current state.

Thank you for maintaining this bundle!