### PR TITLE
Symfony 5 Support

### DIFF
--- a/EventListener/LocaleListener.php
+++ b/EventListener/LocaleListener.php
@@ -11,7 +11,7 @@ namespace Prezent\Doctrine\TranslatableBundle\EventListener;
 
 use Prezent\Doctrine\Translatable\EventListener\TranslatableListener;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
@@ -39,10 +39,10 @@ class LocaleListener implements EventSubscriberInterface
     /**
      * Set request locale
      *
-     * @param GetResponseEvent $event
+     * @param RequestEvent $event
      * @return void
      */
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelRequest(RequestEvent $event)
     {
         $this->translatableListener->setCurrentLocale($event->getRequest()->getLocale());
     }

--- a/composer.json
+++ b/composer.json
@@ -24,11 +24,11 @@
     "require": {
         "doctrine/doctrine-bundle": "^1.2|^2.0",
         "prezent/doctrine-translatable": "^1.0|^2.0",
-        "symfony/config": "^2.7|^3.0|^4.0",
-        "symfony/dependency-injection": "^2.7|^3.0|^4.0",
-        "symfony/event-dispatcher": "^2.7|^3.0|^4.0",
-        "symfony/http-foundation": "^2.7|^3.0|^4.0",
-        "symfony/http-kernel": "^2.7|^3.0|^4.0"
+        "symfony/config": "^2.7|^3.0|^4.0|^5.0",
+        "symfony/dependency-injection": "^2.7|^3.0|^4.0|^5.0",
+        "symfony/event-dispatcher": "^2.7|^3.0|^4.0|^5.0",
+        "symfony/http-foundation": "^2.7|^3.0|^4.0|^5.0",
+        "symfony/http-kernel": "^2.7|^3.0|^4.0|^5.0"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^4.1"


### PR DESCRIPTION
Dear Prezent Team,

as far as I can see, supporting symfony 5 is just a matter of removing a deprecated class and updating the `composer.json`.

The manual test I have made worked well, however I don't know how this might affect BC or how to handle a possible release that won't break BC.

Are you intersted in supporting Symfony 5? What can I do to help?

Barthy