### PR TITLE
Resolved Symfony 5.4 deprecation

### DIFF
--- a/EventListener/LocaleListener.php
+++ b/EventListener/LocaleListener.php
@@ -50,7 +50,7 @@ class LocaleListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    static public function getSubscribedEvents()
+    static public function getSubscribedEvents(): array
     {
         return array(
             KernelEvents::REQUEST => array(array('onKernelRequest', 10)),


### PR DESCRIPTION
Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Prezent\Doctrine\TranslatableBundle\EventListener\LocaleListener" now to avoid errors or add an explicit @return annotation to suppress this message.